### PR TITLE
Consider when the file is used with pnpm isolated mode.

### DIFF
--- a/util.js
+++ b/util.js
@@ -2,8 +2,37 @@ const fs = require('fs');
 const path = require('path');
 
 const encoding = "utf8";
-const folder = `${__dirname}/../`;
-const packageName = 'svg'
+
+/**
+ * Retrieve the absolute path to the `@mdi/svg` package.
+ * 
+ * If using from the root of a project, it will return the `node_modules/@mdi/svg` path.
+ * Otherwise, it will fallback to 0.3.2 behavior (without validating that it exists).
+ * 
+ * This help for pnpm in isolated mode where the 0.3.2 behavior try to find the `@mdi/svg` package
+ * somewhere in the `.pnpm` store.
+ * 
+ * @param {string} overridePackageName 
+ * @returns the absolute path to the `@mdi/svg` package.
+ */
+ const getSVGPackagePath = (overridePackageName = undefined) => {
+  const pkgName = overridePackageName || "svg";
+  const mdi_svg_path = path.resolve(
+    process.cwd(),
+    "node_modules",
+    "@mdi",
+    pkgName
+  );
+
+  if (fs.existsSync(mdi_svg_path)) {
+    return path.resolve(mdi_svg_path);
+  } else {
+    // Did not find the folder of the package.
+    // Fallback to the 0.3.2 behavior.
+    return path.resolve(parent_folder, pkgName);
+  }
+};
+
 /**
  * Read a file and return it's parsed JSON.
  * 
@@ -21,6 +50,9 @@ const readJSONtoObject = (filename, overridePackageName = undefined) => {
   const file = fs.readFileSync(filepath, { encoding });
   return JSON.parse(file);
 };
+
+const parent_folder = path.resolve(`${__dirname}/../`);
+const svg_package = getSVGPackagePath();
 
 const getVersion = (overridePackageName = undefined) => {
   const file = readJSONtoObject("package.json", overridePackageName);

--- a/util.js
+++ b/util.js
@@ -1,19 +1,19 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 /**
  * Retrieve the absolute path to the `@mdi/svg` package.
- * 
+ *
  * If using from the root of a project, it will return the `node_modules/@mdi/svg` path.
  * Otherwise, it will fallback to 0.3.2 behavior (without validating that it exists).
- * 
+ *
  * This help for pnpm in isolated mode where the 0.3.2 behavior try to find the `@mdi/svg` package
  * somewhere in the `.pnpm` store.
- * 
- * @param {string} overridePackageName 
+ *
+ * @param {string} overridePackageName
  * @returns the absolute path to the `@mdi/svg` package.
  */
- const getSVGPackagePath = (overridePackageName = undefined) => {
+const getSVGPackagePath = (overridePackageName = undefined) => {
   const pkgName = overridePackageName || "svg";
   const mdi_svg_path = path.resolve(
     process.cwd(),
@@ -33,9 +33,9 @@ const path = require('path');
 
 /**
  * Read a file and return its content.
- * 
- * @param {string} filename 
- * @param {string} overridePackageName 
+ *
+ * @param {string} filename
+ * @param {string} overridePackageName
  * @returns content of the file
  */
 const readFile = (filename, overridePackageName = undefined) => {
@@ -46,13 +46,13 @@ const readFile = (filename, overridePackageName = undefined) => {
   }
 
   return fs.readFileSync(filepath, { encoding: "utf8" });
-}
+};
 
 /**
  * Read a JSON and return an object of the parsed JSON.
- * 
- * @param {string} filename 
- * @param {string} overridePackageName 
+ *
+ * @param {string} filename
+ * @param {string} overridePackageName
  * @returns object of the parsed json
  */
 const readJSONtoObject = (filename, overridePackageName = undefined) => {
@@ -82,19 +82,19 @@ const getMeta = (withPaths, overridePackageName = undefined) => {
 };
 
 exports.getVersionLight = () => {
-  return getVersion('light-svg');
-}
+  return getVersion("light-svg");
+};
 
 exports.getMetaLight = (withPaths) => {
-  return getMeta(withPaths, 'light-svg');
-}
+  return getMeta(withPaths, "light-svg");
+};
 
 exports.getVersion = getVersion;
 
 exports.getMeta = getMeta;
 
 exports.closePath = (path) => {
-  return path.replace(/(\d)M/g, '$1ZM');
+  return path.replace(/(\d)M/g, "$1ZM");
 };
 
 exports.write = (file, data) => {
@@ -102,7 +102,7 @@ exports.write = (file, data) => {
 };
 
 exports.read = (file) => {
-  return fs.readFileSync(file, 'utf8');
+  return fs.readFileSync(file, "utf8");
 };
 
 exports.exists = (file) => {

--- a/util.js
+++ b/util.js
@@ -1,19 +1,34 @@
 const fs = require('fs');
+const path = require('path');
 
 const encoding = "utf8";
 const folder = `${__dirname}/../`;
 const packageName = 'svg'
+/**
+ * Read a file and return it's parsed JSON.
+ * 
+ * @param {string} filename 
+ * @param {string} overridePackageName 
+ * @returns object of the parsed json
+ */
+const readJSONtoObject = (filename, overridePackageName = undefined) => {
+  let filepath = path.resolve(svg_package, filename);
 
-const getVersion = (overridePackageName) => {
-  const pName = overridePackageName || packageName;
-  const file = fs.readFileSync(`${folder}${pName}/package.json`, { encoding });
+  if (overridePackageName !== undefined) {
+    filepath = path.resolve(getSVGPackagePath(overridePackageName), filename);
+  }
+
+  const file = fs.readFileSync(filepath, { encoding });
+  return JSON.parse(file);
+};
+
+const getVersion = (overridePackageName = undefined) => {
+  const file = readJSONtoObject("package.json", overridePackageName);
   return JSON.parse(file).version;
 };
 
-const getMeta = (withPaths, overridePackageName) => {
-  const pName = overridePackageName || packageName;
-  const file = fs.readFileSync(`${folder}${pName}/meta.json`, { encoding });
-  const meta = JSON.parse(file);
+const getMeta = (withPaths, overridePackageName = undefined) => {
+  const meta = readJSONtoObject("meta.json", overridePackageName);
   if (withPaths) {
     const total = meta.length;
     meta.forEach((icon, i) => {

--- a/util.js
+++ b/util.js
@@ -64,7 +64,11 @@ const getMeta = (withPaths, overridePackageName = undefined) => {
   if (withPaths) {
     const total = meta.length;
     meta.forEach((icon, i) => {
-      const svg = fs.readFileSync(`${folder}${pName}/svg/${icon.name}.svg`, { encoding });
+      let svgFile = path.resolve(svg_package, 'svg', `${icon.name}.svg`);
+      if (overridePackageName !== undefined) {
+        svgFile = path.resolve(getSVGPackagePath(overridePackageName), 'svg', `${icon.name}.svg`);
+      }
+      const svg = fs.readFileSync(svgFile, { encoding });
       icon.path = svg.match(/ d="([^"]+)"/)[1];
     });
   }

--- a/util.js
+++ b/util.js
@@ -106,5 +106,5 @@ exports.read = (file) => {
 };
 
 exports.exists = (file) => {
-  return fs.exists(file);
+  return fs.existsSync(file);
 };

--- a/util.js
+++ b/util.js
@@ -1,8 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 
-const encoding = "utf8";
-
 /**
  * Retrieve the absolute path to the `@mdi/svg` package.
  * 
@@ -34,20 +32,31 @@ const encoding = "utf8";
 };
 
 /**
- * Read a file and return it's parsed JSON.
+ * Read a file and return its content.
  * 
  * @param {string} filename 
  * @param {string} overridePackageName 
- * @returns object of the parsed json
+ * @returns content of the file
  */
-const readJSONtoObject = (filename, overridePackageName = undefined) => {
+const readFile = (filename, overridePackageName = undefined) => {
   let filepath = path.resolve(svg_package, filename);
 
   if (overridePackageName !== undefined) {
     filepath = path.resolve(getSVGPackagePath(overridePackageName), filename);
   }
 
-  const file = fs.readFileSync(filepath, { encoding });
+  return fs.readFileSync(filepath, { encoding: "utf8" });
+}
+
+/**
+ * Read a JSON and return an object of the parsed JSON.
+ * 
+ * @param {string} filename 
+ * @param {string} overridePackageName 
+ * @returns object of the parsed json
+ */
+const readJSONtoObject = (filename, overridePackageName = undefined) => {
+  const file = readFile(filename, overridePackageName);
   return JSON.parse(file);
 };
 
@@ -64,11 +73,8 @@ const getMeta = (withPaths, overridePackageName = undefined) => {
   if (withPaths) {
     const total = meta.length;
     meta.forEach((icon, i) => {
-      let svgFile = path.resolve(svg_package, 'svg', `${icon.name}.svg`);
-      if (overridePackageName !== undefined) {
-        svgFile = path.resolve(getSVGPackagePath(overridePackageName), 'svg', `${icon.name}.svg`);
-      }
-      const svg = fs.readFileSync(svgFile, { encoding });
+      let svgFilename = path.join("svg", `${icon.name}.svg`);
+      const svg = readFile(svgFilename, overridePackageName);
       icon.path = svg.match(/ d="([^"]+)"/)[1];
     });
   }


### PR DESCRIPTION
Under pnpm isolated mode, the variable `__dirname` return `./node_modules/.pnpm/@mdi+util@0.3.2/node_modules/@mdi/util`.

Due to the isolated mode of pnpm (default mode), the module `@mdi/svg` is not found at `${__dirname}/../`.

This changes will detect if we have a `node_modules` under the `process.cwd()`. If so, it will use this folder to find `@mdi/svg`.

Note, I am not using yarn, so maybe this one is not working either, but in any case, it should fallback to the previous 0.3.2 behavior if `@mdi/svg`is not found in `node_modules`.